### PR TITLE
Removed redundant link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,3 @@ Especially if, for example, you’re living in Chicago and thinking of relocatin
 ## Next Steps
 
 Read the upcoming lessons on the Technical and Work Experience sections of your resume so you can prepare to write your resume draft. 
-
-<p data-visibility='hidden'>View <a href='https://learn.co/lessons/careers-building-your-resume'>Building Your Resume</a> on Learn.co and start learning to code for free.</p>


### PR DESCRIPTION
"View Building Your Resume on Learn.co and start learning to code for free." - link lead to the same already open page on learn.co